### PR TITLE
task/CLOWDER-24_split-circleci-context-per-project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,16 +112,20 @@ workflows:
       - test-16:
           <<: *project_context
           <<: *release_tag_filter
+          post-steps:
+            - jira/notify:
+                job_type: build
+                scan_commit_body: true
       - test-18:
-          <<: *project_context
-          <<: *release_tag_filter
-      - deploy:
           <<: *project_context
           <<: *release_tag_filter
           post-steps:
             - jira/notify:
-                environment_type: production
-                job_type: deployment
+                job_type: build
+                scan_commit_body: true
+      - deploy:
+          <<: *project_context
+          <<: *release_tag_filter
           requires:
             - test-16
             - test-18

--- a/src/app/templates/.circleci/config.yml
+++ b/src/app/templates/.circleci/config.yml
@@ -112,16 +112,20 @@ workflows:
       - test-16:
           <<: *project_context
           <<: *release_tag_filter
+          post-steps:
+            - jira/notify:
+                job_type: build
+                scan_commit_body: true
       - test-18:
-          <<: *project_context
-          <<: *release_tag_filter
-      - deploy:
           <<: *project_context
           <<: *release_tag_filter
           post-steps:
             - jira/notify:
-                environment_type: production
-                job_type: deployment
+                job_type: build
+                scan_commit_body: true
+      - deploy:
+          <<: *project_context
+          <<: *release_tag_filter
           requires:
             - test-16
             - test-18


### PR DESCRIPTION
removed deploy post notify jira since this project deploy based on a tag release and not a commit with a jira issue

adding post build notify on test
